### PR TITLE
Cargo依存関係を最新に

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-yew = { version = "0.20", features = ["csr"] }
-serde = { version = "1.0", features = ["derive"] }
-serde-wasm-bindgen = "0.4"
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4"
-web-sys = "0.3"
-js-sys = "0.3"
+yew = { version = "0.21.0", features = ["csr"] }
+serde = { version = "1.0.192", features = ["derive"] }
+serde-wasm-bindgen = "0.6.1"
+wasm-bindgen = { version = "0.2.88", features = ["serde-serialize"] }
+wasm-bindgen-futures = "0.4.38"
+web-sys = "0.3.65"
+js-sys = "0.3.65"
 
 [workspace]
 members = ["src-tauri"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,14 +10,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = { version = "1.5", features = [] }
+tauri-build = { version = "1.5.0", features = [] }
 
 [dependencies]
-futures = "0.3.28"
+futures = "0.3.29"
 regex = "1.10.2"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tauri = { version = "1.5", features = [ "dialog-open", "shell-open"] }
+serde = { version = "1.0.192", features = ["derive"] }
+serde_json = "1.0.108"
+tauri = { version = "1.5.2", features = [ "dialog-open", "shell-open"] }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem


### PR DESCRIPTION
先日とマシンを変えたら膨大なエラーが出た。

```
error[E0463]: can't find crate for `core`
  |
  = note: the `wasm32-unknown-unknown` target may not be installed
  = help: consider downloading the target with `rustup target add wasm32-unknown-unknown`

error[E0463]: can't find crate for `compiler_builtins`

error[E0463]: can't find crate for `core`
  --> /Users/okunokentaro/.cargo/registry/src/index.crates.io-6f17d22bba15001f/itoa-1.0.9/src/lib.rs:45:5
   |
45 | use core::mem::{self, MaybeUninit};
   |     ^^^^ can't find crate
   |
   = note: the `wasm32-unknown-unknown` target may not be installed
   = help: consider downloading the target with `rustup target add wasm32-unknown-unknown`
```

どうやらこのマシンではWASM開発が初だったらしく、それで必要なターゲットが含まれてなかったぽい。なので追加でインストールを実施。

```
rustup target add wasm32-unknown-unknown
```